### PR TITLE
Add support for subscription id

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arm-credentials",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "description": "VSTS task for copying Azure endpoint credentials into secure variables that can be used by subsequent tasks",
   "main": "./src/bootstraper.js",
   "author": "Objectivity Ltd",

--- a/src/inputs.js
+++ b/src/inputs.js
@@ -12,6 +12,7 @@ function getVariablesNames() {
     names.serviceprincipalid = tl.getInput("ServicePrincipalIdVariableName", true);
     names.servicePrincipalKey = tl.getInput("ServicePrincipalKeyVariableName", true);
     names.tenantId = tl.getInput("TenantIdVariableName", true);
+    names.subscriptionId = tl.getInput("SubscriptionIdVariableName", true);
 
     return names;
 }

--- a/src/logic.js
+++ b/src/logic.js
@@ -7,11 +7,14 @@ function getARMCredentials(connectedService, variableNames) {
     var servicePrincipalId = tl.getEndpointAuthorizationParameter(connectedService, "serviceprincipalid", false);
     var servicePrincipalKey = tl.getEndpointAuthorizationParameter(connectedService, "serviceprincipalkey", false);
     var tenantId = tl.getEndpointAuthorizationParameter(connectedService, "tenantid", false);
+    var subscriptionId = tl.getEndpointDataParameter(connectedService, "subscriptionId", true);
+     
 
     var secrets = [];
     secrets.push({ name: variableNames.serviceprincipalid, value: servicePrincipalId });
     secrets.push({ name: variableNames.servicePrincipalKey, value: servicePrincipalKey });
     secrets.push({ name: variableNames.tenantId, value: tenantId });
+    secrets.push({ name: variableNames.subscriptionId, value: subscriptionId });
 
     return secrets;
 }

--- a/task.json
+++ b/task.json
@@ -11,9 +11,9 @@
   ],
   "demands": [],
   "version": {
-    "Major": "0",
-    "Minor": "1",
-    "Patch": "1"
+    "Major": "1",
+    "Minor": "0",
+    "Patch": "0"
   },
   "minimumAgentVersion": "1.95.0",
   "instanceNameFormat": "ARM Credentials",
@@ -65,6 +65,15 @@
         "required": true,
         "groupName": "VariablesDetails",
         "helpMarkDown": "The name of the secure variable under which tenantId will be saved"
+    },
+    {
+        "name": "SubscriptionIdVariableName",
+        "type": "string",
+        "label": "Variable name for subscriptionId",
+        "defaultValue": "subscriptionId",
+        "required": true,
+        "groupName": "VariablesDetails",
+        "helpMarkDown": "The name of the secure variable under which subscriptionId will be saved"
     }
   ],
   "execution": {


### PR DESCRIPTION
This change adds support for retrieving subscription id from service connection.

I decided to update version to 1.0.0 instead of 0.1.2.
This allows you to choose the version of the extension in Azure DevOps.
